### PR TITLE
require Pillow < 7.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ PY3 = sys.version_info[0] >= 3
 VERSION = "0.2.4"
 
 INSTALL_REQUIRES = (
-    'Pillow',
+    'Pillow<7.1.0',
 )
 
 TESTS_REQUIRE = (


### PR DESCRIPTION
Because we forked this and haven't maintained this.
Pillow 7.1.0 breaks our app.